### PR TITLE
feat: Update scripts and JS for Hubverse V2 data structure

### DIFF
--- a/.github/workflows/process-data.yml
+++ b/.github/workflows/process-data.yml
@@ -39,20 +39,33 @@ jobs:
    - name: Install dependencies
      run: |
        python -m pip install --upgrade pip
-       pip install pandas numpy pyarrow tqdm logging typing
+       pip install pandas numpy pyarray tqdm logging typing pydantic
        
    - name: Process FluSight data
      run: |
        mkdir -p app/public/processed_data
        python scripts/process_flusight_data.py --hub-path ./FluSight-forecast-hub --output-path ./app/public/processed_data
-       echo "Checking processed files:"
-       ls -la app/public/processed_data/
+       echo "Checking processed FluSight files:"
+       ls -la app/public/processed_data/datasets/flusight/projections/
+       ls -la app/public/processed_data/datasets/flusight/
        
    - name: Process RSV data
      run: |
        python scripts/process_rsv_data.py --hub-path ./rsv-forecast-hub --output-path ./app/public/processed_data
        echo "Checking processed RSV files:"
-       ls -la app/public/processed_data/rsv/
+       ls -la app/public/processed_data/datasets/rsv_hub/projections/ # V2 path
+       ls -la app/public/processed_data/datasets/rsv_hub/ # V2 path for metadata
+       
+   - name: Process NHSN data
+     run: |
+       python scripts/process_nhsn_data.py --output-path ./app/public/processed_data --locations-path ./FluSight-forecast-hub/auxiliary-data/locations.csv
+       echo "Checking processed NHSN files:"
+       ls -la app/public/processed_data/datasets/nhsn/timeseries/ # V2 path
+       ls -la app/public/processed_data/datasets/nhsn/ # V2 path for metadata
+
+   - name: Validate processed data
+     run: |
+       python scripts/validate_processed_data.py app/public/processed_data
        
    - name: Upload processed data
      uses: actions/upload-artifact@v4

--- a/app/src/components/ForecastViz.jsx
+++ b/app/src/components/ForecastViz.jsx
@@ -158,13 +158,20 @@ const ForecastViz = ({ location, handleStateSelect }) => {
         // setModels([]);
 
         // Determine which file to load based on view type
-        const prefix = viewType === 'rsvdetailed' ? 'rsv' : 'flusight';
-        const url = getDataPath(`${prefix}/${location}_${prefix}.json`);
+        const dataPathForFetching = currentDataset?.dataPath;
+        if (!dataPathForFetching) {
+            console.error("dataPath not found in currentDataset", currentDataset);
+            setError(`Data path not configured for dataset: ${currentDataset?.shortName || 'current view'}`);
+            setLoading(false);
+            return;
+        }
+
+        const url = getDataPath(`${dataPathForFetching}/${location}.json`);
         console.log('Attempting to fetch:', url);
 
         const response = await fetch(url);
         if (!response.ok) {
-          throw new Error(`Failed to load ${prefix} data for ${location} (status ${response.status})`);
+          throw new Error(`Failed to load data from ${url} for ${location} (status ${response.status})`);
         }
 
         const text = await response.text();

--- a/app/src/config/datasets.js
+++ b/app/src/config/datasets.js
@@ -8,7 +8,7 @@ export const DATASETS = {
     hasDateSelector: true,
     hasModelSelector: true,
     prefix: 'flu',
-    dataPath: 'flusight'
+    dataPath: 'datasets/flusight/projections'
   },
   rsv: {
     shortName: 'rsv',
@@ -19,7 +19,7 @@ export const DATASETS = {
     hasDateSelector: true,
     hasModelSelector: true,
     prefix: 'rsv',
-    dataPath: 'rsv'
+    dataPath: 'datasets/rsv_hub/projections'
   },
   nhsn: {
     shortName: 'nhsn',
@@ -29,7 +29,7 @@ export const DATASETS = {
     hasDateSelector: false,
     hasModelSelector: false,
     prefix: 'nhsn',
-    dataPath: 'nhsn'
+    dataPath: 'datasets/nhsn/timeseries'
   }
 };
 

--- a/scripts/process_flusight_data.py
+++ b/scripts/process_flusight_data.py
@@ -239,6 +239,14 @@ class FluSightPreprocessor:
 
         # Save metadata about available models
         metadata = {
+            "shortName": "flusight",
+            "fullName": "FluSight Hospitalisation Forecasts",
+            "defaultView": "detailed",
+            "targets": ["wk inc flu hosp"], # Primary target, other seasonal/peak targets might be present in data
+            "quantile_levels": [
+                0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45,
+                0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.975, 0.99
+            ], # Standard 23 quantiles
             'last_updated': pd.Timestamp.now().strftime('%Y-%m-%d %H:%M:%S'),
             'models': sorted(list(self.all_models)),  # Keep global list here
             'locations': [
@@ -254,12 +262,16 @@ class FluSightPreprocessor:
             'demo_mode': self.demo_mode
         }
 
-        # Create flusight subdirectory
-        payload_path = self.output_path / "flusight"
-        payload_path.mkdir(parents=True, exist_ok=True)
+        # Path for dataset metadata
+        dataset_metadata_path = self.output_path / "datasets" / "flusight"
+        dataset_metadata_path.mkdir(parents=True, exist_ok=True)
 
-        with open(payload_path / 'metadata.json', 'w') as f:
+        with open(dataset_metadata_path / 'metadata.json', 'w') as f:
             json.dump(metadata, f, indent=2)
+
+        # Path for location-specific projection files
+        payload_path = self.output_path / "datasets" / "flusight" / "projections"
+        payload_path.mkdir(parents=True, exist_ok=True)
 
         # Create and save location-specific payloads
         for _, location_info in tqdm(locations.iterrows(), desc="Creating location payloads"):
@@ -301,7 +313,7 @@ class FluSightPreprocessor:
             location_abbrev = str(location_info['abbreviation']).strip()
             if not location_abbrev:
                 continue  # Skip if no valid abbreviation
-            with open(payload_path / f"{location_abbrev}_flusight.json", 'w') as f:
+            with open(payload_path / f"{location_abbrev}.json", 'w') as f:
                 json.dump(payload, f, cls=NpEncoder)
 
 class NpEncoder(json.JSONEncoder):

--- a/scripts/process_flusight_data.py
+++ b/scripts/process_flusight_data.py
@@ -261,7 +261,7 @@ class FluSightPreprocessor:
                 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45,
                 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.975, 0.99
             ],
-            'last_updated': pd.Timestamp.now(), # Pydantic will convert to ISO string
+            'last_updated': pd.Timestamp.now().to_pydatetime(), # Convert to standard Python datetime
             'models': sorted(list(self.all_models)),
             'locations': [
                 {
@@ -285,7 +285,7 @@ class FluSightPreprocessor:
             with open(dataset_metadata_filename, 'w') as f:
                 # Pydantic's .dict() handles datetime to ISO string conversion.
                 # by_alias=True is good practice if your models use aliases.
-                json.dump(validated_dataset_metadata.dict(by_alias=True), f, indent=2)
+                json.dump(validated_dataset_metadata.model_dump(by_alias=True, mode='json'), f, indent=2)
             logger.info(f"Successfully validated and saved dataset metadata to {dataset_metadata_filename}")
         except ValidationError as e:
             logger.error(f"Validation Error for dataset metadata {dataset_metadata_filename}: {e}")
@@ -325,8 +325,8 @@ class FluSightPreprocessor:
             try:
                 validated_loc_projection = FluSightLocationProjectionsFile(**payload_for_validation)
                 with open(output_filename, 'w') as f:
-                    # Using NpEncoder because forecast_data can contain numpy types not handled by Pydantic's .dict()
-                    json.dump(validated_loc_projection.dict(by_alias=True), f, indent=2, cls=NpEncoder)
+                    # Relying on Pydantic V2's model_dump(mode='json') to handle type coercion for standard JSON.
+                    json.dump(validated_loc_projection.model_dump(by_alias=True, mode='json'), f, indent=2)
                 # logger.info(f"Successfully validated and saved projection for {location_abbrev} to {output_filename}")
             except ValidationError as e:
                 logger.error(f"Validation Error for projection {output_filename}: {e}")

--- a/scripts/process_nhsn_data.py
+++ b/scripts/process_nhsn_data.py
@@ -186,10 +186,10 @@ class NHSNDataDownloader:
             validated_dataset_meta = NHSNDatasetMetadata(**nhsn_metadata_dict)
             # Save dataset metadata to args.output_path
             with open(dataset_metadata_output_file, 'w') as f:
-                json.dump(validated_dataset_meta.dict(by_alias=True), f, indent=2)
+                json.dump(validated_dataset_meta.model_dump(by_alias=True, mode='json'), f, indent=2)
             # Save dataset metadata to app/public path
             with open(dataset_metadata_app_public_file, 'w') as f:
-                json.dump(validated_dataset_meta.dict(by_alias=True), f, indent=2)
+                json.dump(validated_dataset_meta.model_dump(by_alias=True, mode='json'), f, indent=2)
             logger.info(f"Successfully validated and saved NHSN dataset metadata to {dataset_metadata_output_file} and {dataset_metadata_app_public_file}")
         except ValidationError as e:
             logger.error(f"Validation Error for NHSN dataset metadata ({dataset_metadata_output_file.name}): {e}")
@@ -307,9 +307,9 @@ class NHSNDataDownloader:
                     try:
                         validated_timeseries_file = NHSNLocationTimeseriesFile(**final_location_data)
                         with open(output_file, 'w') as f:
-                            json.dump(validated_timeseries_file.dict(by_alias=True), f, indent=2)
+                            json.dump(validated_timeseries_file.model_dump(by_alias=True, mode='json'), f, indent=2)
                         with open(app_output_file, 'w') as f:
-                            json.dump(validated_timeseries_file.dict(by_alias=True), f, indent=2)
+                            json.dump(validated_timeseries_file.model_dump(by_alias=True, mode='json'), f, indent=2)
                         # logger.info(f"Successfully validated and saved timeseries for {location} to {output_file} and {app_output_file}")
                     except ValidationError as e:
                         logger.error(f"Validation Error for timeseries file {output_file.name}: {e}")

--- a/scripts/process_rsv_data.py
+++ b/scripts/process_rsv_data.py
@@ -301,7 +301,7 @@ class RSVPreprocessor:
                 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45,
                 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.975, 0.99
             ], # Standard 23 quantiles
-            'last_updated': pd.Timestamp.now(), # Pydantic will convert to ISO string
+            'last_updated': pd.Timestamp.now().to_pydatetime(), # Convert to standard Python datetime
             'models': sorted(list(self.all_models)),
             'age_groups': self.age_groups,
             'locations': [
@@ -324,7 +324,7 @@ class RSVPreprocessor:
         try:
             validated_dataset_metadata = RSVHubDatasetMetadata(**dataset_metadata_dict)
             with open(dataset_metadata_filename, 'w') as f:
-                json.dump(validated_dataset_metadata.dict(by_alias=True), f, indent=2)
+                json.dump(validated_dataset_metadata.model_dump(by_alias=True, mode='json'), f, indent=2)
             logger.info(f"Successfully validated and saved dataset metadata to {dataset_metadata_filename}")
         except ValidationError as e:
             logger.error(f"Validation Error for dataset metadata {dataset_metadata_filename}: {e}")
@@ -365,7 +365,7 @@ class RSVPreprocessor:
                 validated_loc_projection = RSVLocationProjectionsFile(**payload_for_validation)
                 with open(output_filename, 'w') as f:
                     # The original script did not use NpEncoder for RSV, Pydantic's .dict() should handle standard types.
-                    json.dump(validated_loc_projection.dict(by_alias=True), f, indent=2)
+                    json.dump(validated_loc_projection.model_dump(by_alias=True, mode='json'), f, indent=2)
                 # logger.info(f"Successfully validated and saved projection for {location_abbrev} to {output_filename}")
             except ValidationError as e:
                 logger.error(f"Validation Error for projection {output_filename}: {e}")

--- a/scripts/schemas/common_types.py
+++ b/scripts/schemas/common_types.py
@@ -1,5 +1,6 @@
+import math # Add for math.isclose
 from typing import List, Union, Dict, Any, Optional
-from pydantic import BaseModel, HttpUrl, confloat, conint, Field, validator
+from pydantic import BaseModel, HttpUrl, confloat, conint, Field, validator, root_validator
 from datetime import datetime
 # Try importing Annotated from typing_extensions first, then typing for broader compatibility
 try:
@@ -32,12 +33,62 @@ class QuantilePrediction(BaseModel):
 class ModelPredictions(BaseModel):
     type: Annotated[str, Field(pattern=r"^(quantile|point|pmf|sample)$")] # Extend as needed
     # predictions is a dictionary where keys are horizon strings e.g. "0", "1", "-1"
-    # Using str for keys; regex validation for dict keys can be done via a separate validator if essential
-    predictions: Dict[str, QuantilePrediction]
+    predictions: Dict[str, Union[QuantilePrediction, PMFPrediction]] # Updated type hint
 
-    @validator('predictions')
+    @validator('predictions') # This existing validator checks keys like "-1", "0"
     def check_prediction_keys_are_valid_horizons(cls, v):
         for key in v.keys():
-            if not isinstance(key, str) or not key.strip('-').isdigit(): # Simple check for "integer-like strings"
+            if not isinstance(key, str) or not key.strip('-').isdigit():
                  raise ValueError(f"Prediction key '{key}' must be an integer-like string (e.g., '-1', '0', '10').")
+        return v
+
+    @root_validator(pre=False, skip_on_failure=True) # post-validation, skip if other field validations failed
+    def check_predictions_match_type(cls, values):
+        # 'values' here is a dict of the model's fields after individual field validation
+        model_type = values.get('type')
+        predictions_dict = values.get('predictions')
+
+        if not model_type or not predictions_dict:
+            # This should not happen if 'type' and 'predictions' are required fields
+            # or if skip_on_failure=True handles it.
+            # Can raise an error or return values if other validators should catch missing type/predictions.
+            return values # Or raise error if type/predictions are mandatory and somehow missing here
+
+        for horizon_key, prediction_obj in predictions_dict.items():
+            if model_type == "quantile":
+                if not isinstance(prediction_obj, QuantilePrediction):
+                    raise ValueError(
+                        f"For model type 'quantile', prediction for horizon '{horizon_key}' "
+                        f"must be a QuantilePrediction object, got {type(prediction_obj).__name__}."
+                    )
+            elif model_type == "pmf":
+                if not isinstance(prediction_obj, PMFPrediction):
+                    raise ValueError(
+                        f"For model type 'pmf', prediction for horizon '{horizon_key}' "
+                        f"must be a PMFPrediction object, got {type(prediction_obj).__name__}."
+                    )
+            # Add elif for other types like 'point', 'sample' when their models are defined
+            # else:
+                # This case should ideally not be reached if 'type' field is validated against allowed enum/literal
+                # raise ValueError(f"Unknown model type '{model_type}' encountered in validator.")
+
+        return values
+
+# Model for PMF (Probability Mass Function) predictions
+class PMFPrediction(BaseModel):
+    date: DateStr
+    categories: List[str]
+    probabilities: List[confloat(ge=0, le=1)]
+
+    @validator('probabilities')
+    def check_probabilities_sum(cls, v):
+        if not math.isclose(sum(v), 1.0, abs_tol=0.001): # Allow for small floating point inaccuracies
+            raise ValueError('Probabilities must sum to 1.0')
+        return v
+
+    @validator('probabilities')
+    def check_categories_probabilities_length(cls, v, values):
+        # This validator style is for Pydantic V1 where 'values' contains already validated fields
+        if 'categories' in values and len(v) != len(values['categories']):
+            raise ValueError('categories and probabilities lists must have the same length')
         return v

--- a/scripts/schemas/common_types.py
+++ b/scripts/schemas/common_types.py
@@ -19,7 +19,7 @@ class LocationBase(BaseModel):
 
 # Model for quantile predictions (most common in current scripts)
 class QuantilePrediction(BaseModel):
-    target_end_date: DateStr
+    date: DateStr # Changed from target_end_date
     quantiles: List[confloat(ge=0, le=1)]
     values: List[Optional[float]] # Allow for nulls if data can be missing
 

--- a/scripts/schemas/common_types.py
+++ b/scripts/schemas/common_types.py
@@ -1,0 +1,30 @@
+from typing import List, Union, Dict, Any, Optional
+from pydantic import BaseModel, HttpUrl, constr, confloat, conint, validator
+from datetime import datetime
+
+# Basic types
+LocationAbbrev = constr(regex=r"^[A-Z0-9]{2,3}$") # US, AL, 01 etc.
+DateStr = constr(regex=r"^\d{4}-\d{2}-\d{2}$") # YYYY-MM-DD
+
+class LocationBase(BaseModel):
+    location: LocationAbbrev
+    abbreviation: str # Could be the same as location or different (e.g. US vs US)
+    name: str
+    population: Optional[conint(ge=0)] = None # Optional population
+
+# Model for quantile predictions (most common in current scripts)
+class QuantilePrediction(BaseModel):
+    target_end_date: DateStr
+    quantiles: List[confloat(ge=0, le=1)]
+    values: List[Union[float, None]] # Allow for nulls if data can be missing
+
+    @validator('values')
+    def check_quantiles_values_length(cls, v, values):
+        if 'quantiles' in values and len(v) != len(values['quantiles']):
+            raise ValueError('quantiles and values lists must have the same length')
+        return v
+
+class ModelPredictions(BaseModel):
+    type: constr(regex=r"^(quantile|point|pmf|sample)$") # Extend as needed
+    # predictions is a dictionary where keys are horizon strings e.g. "0", "1", "-1"
+    predictions: Dict[constr(regex=r"^-?\d+$"), QuantilePrediction] # Defaulting to QuantilePrediction as it's most detailed in spec

--- a/scripts/schemas/dataset_metadata.py
+++ b/scripts/schemas/dataset_metadata.py
@@ -1,0 +1,43 @@
+from typing import List, Optional
+from pydantic import BaseModel, validator, HttpUrl
+from datetime import datetime
+from .common_types import LocationBase # Assuming common_types.py is in the same directory
+
+class BaseDatasetMetadata(BaseModel):
+    shortName: str
+    fullName: str
+    defaultView: Optional[str] = None
+    targets: List[str]
+    quantile_levels: Optional[List[float]] = None # Optional as not all datasets might have it
+    last_updated: Optional[datetime] = None
+    models: Optional[List[str]] = None # List of model names
+    # Kept locations for now per previous discussion, can be removed if global locations.json is sole source
+    locations: Optional[List[LocationBase]] = None
+    demo_mode: Optional[bool] = None
+
+class FluSightDatasetMetadata(BaseDatasetMetadata):
+    shortName: str = "flusight"
+    # Example targets, adjust if script uses different ones
+    targets: List[str] = ["wk inc flu hosp", "wk flu hosp rate change", "peak week", "peak inc"]
+    # Example quantiles, adjust from script if different
+    quantile_levels: List[float] = [
+        0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5,
+        0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.975, 0.99
+    ]
+
+class RSVHubDatasetMetadata(BaseDatasetMetadata):
+    shortName: str = "rsv_hub"
+    targets: List[str] = ["inc hosp"] # Main target for RSV
+    age_groups: Optional[List[str]] = None
+    quantile_levels: List[float] = [ # Example
+        0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5,
+        0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.975, 0.99
+    ]
+
+class NHSNDatasetMetadata(BaseModel): # NHSN is simpler as per data-format.md
+    shortName: str = "nhsn"
+    fullName: str = "National Healthcare Safety Network Data"
+    description: Optional[str] = None
+    last_updated: Optional[datetime] = None
+    # No targets/quantiles specified for NHSN dataset-level metadata in data-format.md
+    # It's primarily timeseries columns.

--- a/scripts/schemas/global_metadata.py
+++ b/scripts/schemas/global_metadata.py
@@ -1,0 +1,26 @@
+from typing import List, Dict, Optional
+from pydantic import BaseModel, HttpUrl
+from datetime import datetime
+from .common_types import LocationBase # LocationBase is suitable here
+
+# For the main processed_data/locations.json
+class LocationsFile(BaseModel):
+    # The file is a list of location objects
+    __root__: List[LocationBase]
+
+# For the dataset entries within the global processed_data/metadata.json
+class GlobalDatasetEntry(BaseModel):
+    fullName: str
+    views: List[str] # e.g. ["detailed", "timeseries"]
+    prefix: str # e.g. "flu", "rsv", "nhsn" - used for URL params, etc.
+    dataPath: str # e.g. "datasets/flusight/projections", "datasets/nhsn/timeseries"
+    hasModelSelector: Optional[bool] = None
+    hasDateSelector: Optional[bool] = None
+    # Other fields from data-format.md Section 3 can be added here if needed by the application
+    # For example, defaultModel, defaultView (though defaultView is more of a UI concern)
+
+# For the global processed_data/metadata.json
+class GlobalMetadataFile(BaseModel):
+    build_timestamp: datetime
+    datasets: Dict[str, GlobalDatasetEntry] # Keyed by dataset shortName e.g. "flusight", "rsv_hub", "nhsn"
+    demo_mode: Optional[bool] = None

--- a/scripts/schemas/projections.py
+++ b/scripts/schemas/projections.py
@@ -1,0 +1,40 @@
+from typing import Dict, List, Optional
+from pydantic import BaseModel
+from .common_types import DateStr, ModelPredictions, LocationBase
+
+# Basic building blocks for forecast data
+ModelNameStr = str
+ModelData = Dict[ModelNameStr, ModelPredictions]
+
+TargetNameStr = str
+TargetData = Dict[TargetNameStr, ModelData]
+
+# Forecast structure for FluSight-like data (no age groups)
+# e.g., "2025-02-01": { "wk inc flu hosp": { "modelA": { ... } } }
+Forecasts = Dict[DateStr, TargetData]
+
+# Forecast structure for RSV-like data (includes age groups)
+AgeGroupStr = str
+# e.g., "0-4": { "inc hosp": { "modelA": { ... } } }
+RSVTargetDataByAgeGroup = Dict[AgeGroupStr, TargetData]
+# e.g., "2025-02-01": { "0-4": { "inc hosp": { "modelA": { ... } } } }
+RSVForecasts = Dict[DateStr, RSVTargetDataByAgeGroup]
+
+
+# Common metadata structure for individual projection files
+# This metadata is specific to the location file itself
+class FileMetadata(LocationBase): # Inherits location, abbreviation, name, population
+    dataset: str # e.g., "flusight", "rsv_hub"
+    # location field is inherited from LocationBase, which includes location, abbreviation, name, population
+
+# Top-level model for FluSight location projection files
+class FluSightLocationProjectionsFile(BaseModel):
+    metadata: FileMetadata
+    forecasts: Forecasts
+    # No ground_truth or available_models as per V2 projection spec (data-format.md Section 7)
+
+# Top-level model for RSV location projection files
+class RSVLocationProjectionsFile(BaseModel):
+    metadata: FileMetadata
+    forecasts: RSVForecasts
+    # No ground_truth or available_models as per V2 projection spec (data-format.md Section 7)

--- a/scripts/schemas/timeseries.py
+++ b/scripts/schemas/timeseries.py
@@ -1,0 +1,39 @@
+from typing import List, Dict, Optional, Union
+from pydantic import BaseModel, validator, root_validator, constr
+from .common_types import DateStr, LocationAbbrev, LocationBase
+
+class SeriesMetadata(LocationBase): # Reusing LocationBase for common fields
+    dataset: str # e.g., "nhsn"
+    series_type: constr(regex=r"^(official|preliminary)$")
+
+class SeriesData(BaseModel):
+    dates: List[DateStr]
+    # Columns are Dict[column_name, List_of_values]. Values can be float, int, or None.
+    columns: Dict[str, List[Optional[Union[float, int]]]]
+
+    @validator('columns')
+    def check_column_lengths_match_dates(cls, v, values):
+        if 'dates' in values:
+            dates_len = len(values['dates'])
+            for col_name, col_values in v.items():
+                if len(col_values) != dates_len:
+                    raise ValueError(
+                        f"Column '{col_name}' has length {len(col_values)}, "
+                        f"but dates list has length {dates_len}."
+                    )
+        return v
+
+class SingleTimeseries(BaseModel):
+    metadata: SeriesMetadata
+    series: SeriesData
+
+# For NHSN files that contain both "official" and "preliminary" keys
+class NHSNLocationTimeseriesFile(BaseModel):
+    official: Optional[SingleTimeseries] = None
+    preliminary: Optional[SingleTimeseries] = None
+
+    @root_validator
+    def check_at_least_one_series(cls, values):
+        if not values.get('official') and not values.get('preliminary'):
+            raise ValueError("At least one of 'official' or 'preliminary' series must be present.")
+        return values

--- a/scripts/validate_processed_data.py
+++ b/scripts/validate_processed_data.py
@@ -1,0 +1,151 @@
+import argparse
+import json
+import logging
+from pathlib import Path
+import sys
+from pydantic import ValidationError
+
+# Allow imports from the 'schemas' directory, assuming 'scripts' is the parent of 'schemas'
+# and this script is in 'scripts'.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+try:
+    from schemas.global_metadata import GlobalMetadataFile, LocationsFile
+    from schemas.dataset_metadata import FluSightDatasetMetadata, RSVHubDatasetMetadata, NHSNDatasetMetadata
+    from schemas.projections import FluSightLocationProjectionsFile, RSVLocationProjectionsFile
+    from schemas.timeseries import NHSNLocationTimeseriesFile
+except ImportError as e:
+    print(f"Error importing schemas: {e}. Ensure that the 'schemas' directory is in the correct location and PYTHONPATH is set if necessary.")
+    sys.exit(1)
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+SCHEMA_DISPATCH = {
+    "global_metadata": GlobalMetadataFile,
+    "locations": LocationsFile,
+    "flusight": {
+        "dataset_metadata": FluSightDatasetMetadata,
+        "projections": FluSightLocationProjectionsFile,
+    },
+    "rsv_hub": { # Corrected from rsv to rsv_hub to match directory names
+        "dataset_metadata": RSVHubDatasetMetadata,
+        "projections": RSVLocationProjectionsFile,
+    },
+    "nhsn": {
+        "dataset_metadata": NHSNDatasetMetadata,
+        "timeseries": NHSNLocationTimeseriesFile,
+    }
+}
+
+error_count = 0
+validated_file_count = 0
+
+def validate_file(filepath: Path, model_cls, file_description: str):
+    global error_count, validated_file_count
+    
+    if not filepath.exists():
+        logging.warning(f"SKIPPED: {file_description} - File not found: {filepath}")
+        return
+
+    logging.info(f"VALIDATING: {file_description} - {filepath}")
+    validated_file_count += 1
+    try:
+        with open(filepath, 'r') as f:
+            data = json.load(f)
+        model_cls(**data)
+        logging.info(f"OK: {filepath}")
+    except json.JSONDecodeError as e:
+        logging.error(f"ERROR: {filepath} - Invalid JSON: {e}")
+        error_count += 1
+    except ValidationError as e:
+        logging.error(f"ERROR: {filepath} - Schema validation failed:\n{e}")
+        error_count += 1
+    except Exception as e:
+        logging.error(f"ERROR: {filepath} - An unexpected error occurred: {e}")
+        error_count += 1
+
+def main():
+    global error_count, validated_file_count
+
+    parser = argparse.ArgumentParser(description="Validate processed Hubverse JSON data.")
+    parser.add_argument("base_path", type=Path, help="Base path to the processed_data directory (e.g., app/public/processed_data)")
+    args = parser.parse_args()
+
+    base_path: Path = args.base_path
+
+    if not base_path.is_dir():
+        logging.error(f"Specified base path {base_path} is not a directory or does not exist.")
+        sys.exit(1)
+
+    # --- Validate global files ---
+    logging.info("--- Validating Global Files ---")
+    global_metadata_path = base_path / "metadata.json"
+    validate_file(global_metadata_path, SCHEMA_DISPATCH["global_metadata"], "Global metadata.json")
+
+    locations_path = base_path / "locations.json"
+    validate_file(locations_path, SCHEMA_DISPATCH["locations"], "Global locations.json")
+
+    # --- Validate dataset-specific files ---
+    logging.info("\n--- Validating Dataset-Specific Files ---")
+    datasets_path = base_path / "datasets"
+    if not datasets_path.is_dir():
+        logging.warning(f"SKIPPED: Datasets directory not found: {datasets_path}")
+    else:
+        for dataset_dir in datasets_path.iterdir():
+            if not dataset_dir.is_dir():
+                logging.warning(f"Skipping non-directory item in datasets: {dataset_dir.name}")
+                continue
+            
+            dataset_name = dataset_dir.name
+            logging.info(f"\nProcessing dataset: {dataset_name}")
+
+            dataset_schemas = SCHEMA_DISPATCH.get(dataset_name)
+            if not dataset_schemas:
+                logging.warning(f"SKIPPED: No schemas defined for dataset '{dataset_name}' in {dataset_dir}")
+                continue
+
+            # Validate dataset metadata.json
+            dataset_metadata_file = dataset_dir / "metadata.json"
+            if dataset_schemas.get("dataset_metadata"):
+                validate_file(dataset_metadata_file, dataset_schemas["dataset_metadata"], f"Dataset metadata for {dataset_name}")
+            elif dataset_metadata_file.exists():
+                 logging.warning(f"SKIPPED: Found dataset metadata.json for '{dataset_name}' but no schema defined for it: {dataset_metadata_file}")
+
+
+            # Validate projection files
+            projections_path = dataset_dir / "projections"
+            if projections_path.is_dir():
+                if dataset_schemas.get("projections"):
+                    logging.info(f"Validating projection files for {dataset_name} in {projections_path}...")
+                    for proj_file in sorted(projections_path.glob("*.json")):
+                        validate_file(proj_file, dataset_schemas["projections"], f"Projection file for {dataset_name}")
+                else:
+                    logging.warning(f"SKIPPED: Projections directory found for '{dataset_name}' but no projection schema defined: {projections_path}")
+            elif dataset_schemas.get("projections"): # Schema exists but dir doesn't
+                logging.warning(f"SKIPPED: Projections schema defined for '{dataset_name}' but directory not found: {projections_path}")
+
+
+            # Validate timeseries files
+            timeseries_path = dataset_dir / "timeseries"
+            if timeseries_path.is_dir():
+                if dataset_schemas.get("timeseries"):
+                    logging.info(f"Validating timeseries files for {dataset_name} in {timeseries_path}...")
+                    for ts_file in sorted(timeseries_path.glob("*.json")):
+                        validate_file(ts_file, dataset_schemas["timeseries"], f"Timeseries file for {dataset_name}")
+                else:
+                    logging.warning(f"SKIPPED: Timeseries directory found for '{dataset_name}' but no timeseries schema defined: {timeseries_path}")
+            elif dataset_schemas.get("timeseries"): # Schema exists but dir doesn't
+                 logging.warning(f"SKIPPED: Timeseries schema defined for '{dataset_name}' but directory not found: {timeseries_path}")
+    
+    # --- Summary ---
+    logging.info("\n--- Validation Summary ---")
+    logging.info(f"{validated_file_count} files checked.")
+    if error_count > 0:
+        logging.error(f"{error_count} validation error(s) found.")
+        sys.exit(1)
+    else:
+        logging.info("All checked files passed validation.")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/update_all_data_source.sh
+++ b/update_all_data_source.sh
@@ -1,9 +1,17 @@
 # show on error and plot the commands
 set -ex
 
+echo "Processing FluSight data..."
 python scripts/process_flusight_data.py  --hub-path FluSight-forecast-hub  --output-path app/public/processed_data
 
-python scripts/process_nhsn_data.py --output-path ./processed_data --locations-path ./FluSight-forecast-hub/auxiliary-data/locations.csv
+echo "Processing NHSN data..."
+python scripts/process_nhsn_data.py --output-path app/public/processed_data --locations-path ./FluSight-forecast-hub/auxiliary-data/locations.csv
 
-
+echo "Processing RSV data..."
 python scripts/process_rsv_data.py  --hub-path rsv-forecast-hub  --output-path app/public/processed_data
+
+echo "Running validation on processed data..."
+python scripts/validate_processed_data.py app/public/processed_data
+echo "Validation complete."
+
+echo "All data processing and validation finished successfully."


### PR DESCRIPTION
I've implemented changes to align with the new Hubverse data format (RespiLens Data Format v2).

Key changes:

1.  **Python Data Processing Scripts (`process_*.py`):**
    *   I updated the output directory structure to `datasets/<dataset_name>/<type>/<location_code>.json` (e.g., `datasets/flusight/projections/US.json`).
    *   Dataset-level `metadata.json` files are now placed in `datasets/<dataset_name>/metadata.json` and their content is aligned with V2 spec (e.g., adding `shortName`, `fullName`, `targets`, `quantile_levels`).
    *   In `process_nhsn_data.py`, I changed the internal JSON structure for timeseries data to V2 format (top-level "official" and "preliminary" keys, each with "metadata" and "series" objects). Dates are now specific to each series type.

2.  **JavaScript Configuration (`app/src/config/datasets.js`):**
    *   I updated `dataPath` for flu, RSV, and NHSN datasets to reflect the new directory structure (e.g., `flu.dataPath` is now `datasets/flusight/projections`).

3.  **JavaScript Components:**
    *   `NHSNRawView.jsx`:
        *   I modified this to fetch data from the new path (`datasets/nhsn/timeseries/<location>.json`).
        *   I updated it to parse and display data from the V2 NHSN timeseries structure (accessing `data.official.series...` and `data.preliminary.series...`).
    *   `ForecastViz.jsx`:
        *   I modified this to fetch data from new paths for FluSight (`datasets/flusight/projections/<location>.json`) and RSV (`datasets/rsv_hub/projections/<location>.json`).

These changes ensure that the data processing pipeline and frontend visualization are consistent with the new data format specifications.