### PR TITLE
Fix Forecastle game history date display timezone issue

### DIFF
--- a/app/src/components/forecastle/ForecastleStatsModal.jsx
+++ b/app/src/components/forecastle/ForecastleStatsModal.jsx
@@ -746,7 +746,7 @@ const ForecastleStatsModal = ({ opened, onClose }) => {
                       return (
                         <Table.Tr key={game.id}>
                           <Table.Td>
-                            <Text size="sm">{formatDate(game.challengeDate)}</Text>
+                            <Text size="sm">{formatDate(game.playedAt)}</Text>
                           </Table.Td>
                           <Table.Td>
                             <Badge size="sm" variant="light">


### PR DESCRIPTION
The game history was showing the wrong date (one day earlier) due to timezone conversion issues. Changed from using challengeDate (date-only string) to playedAt (full timestamp) for display. This ensures the date shown matches when the game was actually played, regardless of timezone.