### PR TITLE
Fix iPad navigation menu visibility issue

### DIFF
--- a/app/src/components/layout/MainNavigation.jsx
+++ b/app/src/components/layout/MainNavigation.jsx
@@ -28,7 +28,7 @@ const MainNavigation = () => {
       </Group>
 
       {/* Desktop Navigation - Full Buttons */}
-      <Group gap="xs" visibleFrom="lg">
+      <Group gap="xs" visibleFrom="sm">
         {navigationItems.map((item) => (
           <Button
             key={item.href}


### PR DESCRIPTION
Changed desktop navigation breakpoint from 'lg' (1024px) to 'sm' (640px) to match the hamburger menu hide breakpoint. This ensures the navigation is always visible - hamburger on phone (<640px) and full menu on iPad/desktop (>=640px).

Previously, navigation disappeared on iPad portrait (768px) since:
- Hamburger was hidden at 640px+
- Desktop nav only appeared at 1024px+