### PR TITLE
Fix Misspellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Authors: **Emily Przykucki**, Joseph Lemaitre, and others within ACCIDDA, the Atlantic Coast Center for Infectious Disease Dynamics and Analytics.
 
 * **stable version** https://www.RespiLens.com
-* **new features are developped on** https://staging.RespiLens.com, [GitHub](https://github.com/ACCIDDA/RespiLens-staging)
+* **new features are developed on** https://staging.RespiLens.com, [GitHub](https://github.com/ACCIDDA/RespiLens-staging)
 
 RespiLens is a responsive web app to visualize respiratory disease forecasts in the US, focused on accessibility for state health departments and the general public. The RSV, COVID-19 and flu views pull from CDC forecast hubs (collectively known as the Hubverse: [rsv-forecast-hub](https://github.com/CDCgov/rsv-forecast-hub), [covid19-forecast-hub](https://github.com/CDCgov/covid19-forecast-hub), and [FluSight-forecast-hub](https://github.com/cdcepi/FluSight-forecast-hub)), and consolidate pathogen data by location and date into one user-friendly plot. While other visualization tools for FluSight/RSV/COVID-19 Hubverse data may exist, many of them are geared towards academics instead of state health departments and the public, making them less accessible to people who need them. Our goal is to make a dashboard with these users in mind. Presently, RespiLens offers these features:
 - **Ability to link a certain view to a URL to share a forecast.** Select a pathogen, a location, and date(s), and then click the "Share View" button to copy the URL with your settings.
@@ -10,7 +10,7 @@ RespiLens is a responsive web app to visualize respiratory disease forecasts in 
 - Ability to choose any number of dates to visualize on your plot
 - Ability to choose any number of contributing models to visualize on your plot
 - A view with National Healthcare Safety Network data, plotting almost 300 data categories (e.g., Number of Adult COVID-19 Admissions, or Percent Inpatient Beds Occupied by RSV Patients) 
-- **Forecastle**, a daily disease forecasting game, where you can attempt to predict hospitalizations counts for a specific senario and then get scored against participating models.
+- **Forecastle**, a daily disease forecasting game, where you can attempt to predict hospitalizations counts for a specific scenario and then get scored against participating models.
 - **MyRespiLens**, where you can visualize your own data for a specific location without the file leaving your machine.
 
 

--- a/app/src/components/Documentation.jsx
+++ b/app/src/components/Documentation.jsx
@@ -219,7 +219,7 @@ const Documentation = () => {
             Hubverse structure (delineated in detail <Anchor href="https://docs.hubverse.io/en/latest/user-guide/model-output.html" target="_blank" rel="noopener noreferrer">here</Anchor>)
             refers to a tabular structure with a variety of requirements relating to column names and value types. Additionally, the script needs corresponding location
             and ground truth data in order to successfully build a RespiLens projections JSON file. The conversion pipeline's shortlist of requirements is below. Please note that
-            if you pulled your data directly from a Hubverse hub <code>.csv</code> file, it likley already conforms to conversion requirements and you can skip to the next step!
+            if you pulled your data directly from a Hubverse hub <code>.csv</code> file, it likely already conforms to conversion requirements and you can skip to the next step!
            </Text>
            <Text><strong style={{ color: '#2563eb' }}>Data Requirements</strong></Text>
            <List withPadding spacing="xs" size="m">

--- a/app/src/components/reporting/ReportingDelayPage.jsx
+++ b/app/src/components/reporting/ReportingDelayPage.jsx
@@ -558,9 +558,9 @@ const ReportingDelayPage = () => {
           <Stack gap="sm">
             <Title order={3}>Introduction</Title>
             <Text c="dimmed">
-              Do you need nowcasting ? What does your reporting delay distrubution look like ? Let's dive into that using this little app. Nothing leave your computer (say how to check).
-              So upload a data with some columns indicating the refrence date of an event, the report date when it was reported, and the value reported. Optionally you can have other columns like location, age group, or target type to filter the data.
-              You'll see your reporting distrubtion and the so called reporting triangle introduced by (probably Kaitlyn Johnson et al. but really i need to check this). This 
+              Do you need nowcasting ? What does your reporting delay distribution look like ? Let's dive into that using this little app. Nothing leave your computer (say how to check).
+              So upload a data with some columns indicating the reference date of an event, the report date when it was reported, and the value reported. Optionally you can have other columns like location, age group, or target type to filter the data.
+              You'll see your reporting distribution and the so called reporting triangle introduced by (probably Kaitlyn Johnson et al. but really i need to check this). This 
               For any deeper dive open the link below to epinowcast on which this work is based.
             </Text>
             <Group gap="xs">

--- a/scripts/process_RespiLens_data.py
+++ b/scripts/process_RespiLens_data.py
@@ -143,7 +143,7 @@ def main():
     
     if args.flu_metrocast_hub_path:
         # Use HubdataPy to get all flu-metrocast data in one df
-        logger.info("Establishing conneciton to local flu metrocast repository...")
+        logger.info("Establishing connection to local flu metrocast repository...")
         flu_metrocast_hub_conn = connect_hub(args.flu_metrocast_hub_path)
         logger.info("Success ✅")
         logger.info("Collecting data from flu metrocast repo...")
@@ -151,7 +151,7 @@ def main():
         flu_metrocast_locations_data = clean_nan_values(pd.read_csv(Path(args.flu_metrocast_hub_path) / 'auxiliary-data/locations.csv'))
         flu_metrocast_target_data = clean_nan_values(connect_target_data(hub_path=args.flu_metrocast_hub_path, target_type=TargetType.TIME_SERIES).to_table().to_pandas())
         logger.info("Success ✅")
-        # Initialize converter oject
+        # Initialize converter object
         flu_metrocast_processor_object = FluMetrocastDataProcessor(
             data=flu_metrocast_hubverse_df,
             locations_data=flu_metrocast_locations_data,


### PR DESCRIPTION
Hello RespiLens,

This is a small PR that fixes misspellings throughout the codebase. 

These misspellings were detected via the `typos` hook which can be used in concert with `pre-commit` via `.pre-commit-config.yaml` and `_typos.toml` configuration files. 

I dropped these into the repository and ran then via `pre-commit install` and then `pre-commit run --all-files` to find the misspellings and any false positives. Then I corrected the misspellings and removed the two files (I heartily endorse these but you can decide if it's something you want another day!). 

For now, these misspellings (minus the false positives) have been corrected: 

<img width="576" height="489" alt="Screenshot 2026-03-18 at 11 32 42" src="https://github.com/user-attachments/assets/077d786b-c806-4a6c-81c6-534f83a70a0f" />

After correcting, running `pre-commit` again, left this (I wasn't sure if it was actually to be corrected to todo — if yes, then I can also correct it in this PR):

<img width="408" height="60" alt="Screenshot 2026-03-18 at 11 34 44" src="https://github.com/user-attachments/assets/11f53673-5cc5-42c3-a6c8-1f6b95460edd" />